### PR TITLE
Allow zip for list plugin availbale

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update ; \
     php7.0-curl \
     php7.0-xml \
     php7.0-soap \
+    php7.0-zip \
     perl \
     build-essential \
     libapache2-mod-php7.0 \


### PR DESCRIPTION
See issue #10

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description

Allow PHP7.0-zip to allow list of plugin on dashboard of OCSInventory

## Related Issues

See issue #10


## Todos
- [ x ] Tests
- [ x ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Docker host's operating system :
Mysql Server version :

#### Docker informations
Docker compose version : 1.22.0
Docker version : 1.18
