### PR TITLE
Changed tag from 2.7 to latest

### DIFF
--- a/2.7/docker-compose.yml
+++ b/2.7/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ocsapplication:
-    image: ocsinventory/ocsinventory-docker-image:2.7
+    image: ocsinventory/ocsinventory-docker-image:latest
     container_name : ocsinventory-server
     restart: always
     ports:


### PR DESCRIPTION


## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
When run docker-compose pull or up about 2.7 version it's occurring error about manifest not found for this image version.


## Related Issues
Message: 
ERROR: manifest for ocsinventory/ocsinventory-docker-image:2.7 not found: manifest unknown: manifest unknown

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Docker host's operating system : Centos 7.0
Mysql Server version :5.7

#### Docker informations
Docker compose version : 1.18.0, build 8dd22a9
Docker version : 19.03.8, build afacb8b

## Deploy Notes
Changed at line #5  from 2.7 to "latest".

## Impacted Areas in Application
List general components of the application that this PR will affect:
I have changed from 2.7 to the "most recent" version because the information that appears in ocsinventory at docker hub /Tags it's "latest":
 https://hub.docker.com/r/ocsinventory/ocsinventory-docker-image/tags

