### PR TITLE
Update 10-com-server.sh

### DIFF
--- a/2.12.3/docker-entrypoint.d/10-com-server.sh
+++ b/2.12.3/docker-entrypoint.d/10-com-server.sh
@@ -42,6 +42,9 @@ if [ -f ${SRV_CONF_FILE} ]; then
 	done
 fi
 
+# Quick fix https://github.com/OCSInventory-NG/OCSInventory-Docker-Stack/issues/16
+sed -i 's/^.*PerlSetEnv OCS_OPT_DBI_PRINT_ERROR.*$/PerlSetEnv OCS_OPT_DBI_PRINT_ERROR 0/' ${SRV_CONF_FILE}
+
 # Permissions
 chown -R $APACHE_RUN_USER: $OCS_LOG_DIR
 


### PR DESCRIPTION
This pull request includes a quick fix to the `2.12.3/docker-entrypoint.d/10-com-server.sh` script to address an issue from the OCSInventory-NG GitHub repository.

Bug Fixes:

* [`2.12.3/docker-entrypoint.d/10-com-server.sh`](diffhunk://#diff-f0081ac37e74c9c89d2934e0681ef4dcf153dcc4a4fd214c73173e5339f39781R45-R47): Added a `sed` command to modify the `PerlSetEnv OCS_OPT_DBI_PRINT_ERROR` setting in the `SRV_CONF_FILE` to resolve a known issue.Add quick and dirty fix for https://github.com/OCSInventory-NG/OCSInventory-Docker-Stack/issues/16 Add a sed replacement
